### PR TITLE
Feature set model display names

### DIFF
--- a/app/admin/answer.rb
+++ b/app/admin/answer.rb
@@ -13,5 +13,6 @@ ActiveAdmin.register Answer do
 #   permitted
 # end
 
+	permit_params :text, :info, :question_id
 
 end

--- a/app/admin/ballot.rb
+++ b/app/admin/ballot.rb
@@ -13,6 +13,6 @@ ActiveAdmin.register Ballot do
 #   permitted
 # end
 
-  permit_params :date
+  permit_params :date, :admin_id
 
 end

--- a/app/admin/question.rb
+++ b/app/admin/question.rb
@@ -13,5 +13,6 @@ ActiveAdmin.register Question do
 #   permitted
 # end
 
+	permit_params :text, :summary, :friendly_name, :ballot_id
 
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -24,4 +24,8 @@ class AdminUser < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   validates :email, uniqueness: true
+
+  def display_name
+  	"#{email}"
+  end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -15,4 +15,8 @@ class Answer < ActiveRecord::Base
 
   validates :question_id, presence: true
   validates :text, presence: true
+
+  def display_name
+  	"#{text}"
+  end
 end

--- a/app/models/ballot.rb
+++ b/app/models/ballot.rb
@@ -14,4 +14,8 @@ class Ballot < ActiveRecord::Base
 
   validates :date, presence: true
   validates :admin_user_id, presence: true
+
+  def display_name
+  	"#{date}"
+  end
 end

--- a/app/models/ballot.rb
+++ b/app/models/ballot.rb
@@ -13,5 +13,5 @@ class Ballot < ActiveRecord::Base
   belongs_to :admin_user
 
   validates :date, presence: true
-  validates :admin_user, presence: true
+  validates :admin_user_id, presence: true
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -17,4 +17,8 @@ class Question < ActiveRecord::Base
   # make sure ballot ID and text are present. Allows text, summary to be empty.
   validates :ballot_id, presence: true
   validates :text, presence: true
+
+  def display_name
+  	"#{friendly_name}"
+  end
 end

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,5 +1,8 @@
 example_id                              | status | run_time        |
 --------------------------------------- | ------ | --------------- |
-./spec/models/admin_user_spec.rb[1:1:1] | passed | 0.0534 seconds  |
-./spec/models/ballot_spec.rb[1:1:1]     | passed | 0.04902 seconds |
-./spec/models/ballot_spec.rb[1:1:2]     | passed | 0.0089 seconds  |
+./spec/models/admin_user_spec.rb[1:1:1] | passed | 0.09046 seconds |
+./spec/models/ballot_spec.rb[1:1:1]     | failed | 0.00105 seconds |
+./spec/models/ballot_spec.rb[1:1:2]     | failed | 0.00138 seconds |
+./spec/models/question_spec.rb[1:1]     | passed | 0.0943 seconds  |
+./spec/models/question_spec.rb[1:2:1]   | passed | 0.01272 seconds |
+./spec/models/question_spec.rb[1:2:2]   | passed | 0.01343 seconds |

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,5 +1,8 @@
 example_id                              | status | run_time        |
 --------------------------------------- | ------ | --------------- |
 ./spec/models/admin_user_spec.rb[1:1:1] | passed | 0.0534 seconds  |
+./spec/models/answer_spec.rb[1:1]       | passed | 0.10162 seconds |
+./spec/models/answer_spec.rb[1:2:1]     | passed | 0.01378 seconds |
+./spec/models/answer_spec.rb[1:2:2]     | passed | 0.01236 seconds |
 ./spec/models/ballot_spec.rb[1:1:1]     | passed | 0.04902 seconds |
 ./spec/models/ballot_spec.rb[1:1:2]     | passed | 0.0089 seconds  |

--- a/spec/factories/answer_factory.rb
+++ b/spec/factories/answer_factory.rb
@@ -10,9 +10,13 @@
 #  updated_at  :datetime         not null
 #
 
-class Answer < ActiveRecord::Base
-  belongs_to :question
+require 'faker'
 
-  validates :question_id, presence: true
-  validates :text, presence: true
+FactoryGirl.define do
+	factory :answer do
+		text         Faker::Lorem.sentence
+
+		# Associations
+    question
+	end
 end

--- a/spec/factories/question_factory.rb
+++ b/spec/factories/question_factory.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: questions
+#
+#  id            :integer          not null, primary key
+#  text          :text
+#  summary       :text
+#  friendly_name :string
+#  ballot_id     :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
+require 'faker'
+
+FactoryGirl.define do
+	factory :question do
+		text         Faker::Lorem.sentence
+
+		# Associations
+    ballot
+	end
+end

--- a/spec/factories/question_factory.rb
+++ b/spec/factories/question_factory.rb
@@ -11,10 +11,13 @@
 #  updated_at    :datetime         not null
 #
 
-class Question < ActiveRecord::Base
-  belongs_to :ballot
+require 'faker'
 
-  # make sure ballot ID and text are present. Allows text, summary to be empty.
-  validates :ballot_id, presence: true
-  validates :text, presence: true
+FactoryGirl.define do
+	factory :question do
+		text         Faker::Lorem.sentence
+
+		# Associations
+    ballot
+	end
 end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -13,4 +13,21 @@
 require 'spec_helper'
 
 RSpec.describe Answer do
+	it "has a valid factory" do
+ 		expect(FactoryGirl.create(:answer)).to be_valid
+ 	end
+
+	describe 'validates' do
+		before(:each) { @answer = build(:answer) }
+
+		it "is invalid without an associated question id" do
+ 			@answer.question_id = nil
+ 			expect(@answer).not_to be_valid
+		end
+
+		it "is invalid without text" do
+			@answer.text = nil
+			expect(@answer).not_to be_valid
+		end
+	end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -14,4 +14,21 @@
 require 'spec_helper'
 
 RSpec.describe Question do
+	it "has a valid factory" do
+		expect(FactoryGirl.create(:question)).to be_valid
+	end
+
+	describe 'validates' do
+		before(:each) { @question = build(:question) }
+
+		it "is invalid without an associated ballot id" do
+			@question.ballot_id = nil
+			expect(@question).not_to be_valid
+		end
+
+		it "is invalid without text" do
+			@question.text = nil
+			expect(@question).not_to be_valid
+		end
+	end
 end


### PR DESCRIPTION
Sets friendly display names for objects in the admin interface instead of non-user-friendly identifiers. 

PR also includes previous commits. 
